### PR TITLE
Feat: 챌린지 조회 API 구현 완료

### DIFF
--- a/src/main/java/com/fisa/appcard/controller/AuthenticationController.java
+++ b/src/main/java/com/fisa/appcard/controller/AuthenticationController.java
@@ -1,10 +1,12 @@
 package com.fisa.appcard.controller;
 
 import com.fisa.appcard.dto.request.InitiateAuthRequest;
+import com.fisa.appcard.dto.request.RegisterKeyRequest;
 import com.fisa.appcard.dto.response.ChallengeResponse;
 import com.fisa.appcard.dto.response.InitiateAuthResponse;
 import com.fisa.appcard.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,6 +30,15 @@ public class AuthenticationController {
     @GetMapping("/{txnId}/challenge")
     public ChallengeResponse challenge(@PathVariable String txnId) {
         return new ChallengeResponse(authService.getChallenge(txnId));
+    }
+
+    /**
+     * 공개키 DB 등록 API
+     */
+    @PostMapping("/registerKey")
+    public ResponseEntity<Void> registerKey(@RequestBody RegisterKeyRequest req) {
+        authService.registerPublicKey(req.getCardId(), req.getPublicKey());
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/fisa/appcard/controller/AuthenticationController.java
+++ b/src/main/java/com/fisa/appcard/controller/AuthenticationController.java
@@ -1,13 +1,11 @@
 package com.fisa.appcard.controller;
 
 import com.fisa.appcard.dto.request.InitiateAuthRequest;
+import com.fisa.appcard.dto.response.ChallengeResponse;
 import com.fisa.appcard.dto.response.InitiateAuthResponse;
 import com.fisa.appcard.service.AuthService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/authentications")
@@ -22,6 +20,14 @@ public class AuthenticationController {
     @PostMapping
     public InitiateAuthResponse initiate(@RequestBody InitiateAuthRequest req) {
         return authService.initiate(req);
+    }
+
+    /**
+     * 챌린지 조회 API
+     */
+    @GetMapping("/{txnId}/challenge")
+    public ChallengeResponse challenge(@PathVariable String txnId) {
+        return new ChallengeResponse(authService.getChallenge(txnId));
     }
 
 }

--- a/src/main/java/com/fisa/appcard/domain/AppCardKey.java
+++ b/src/main/java/com/fisa/appcard/domain/AppCardKey.java
@@ -1,0 +1,32 @@
+package com.fisa.appcard.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "app_card_keys")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppCardKey {
+
+    /**
+     * 카드의 고유 ID값
+     */
+    @Id
+    @Column(name = "card_id", length = 64)
+    private String cardId;
+
+    /**
+     * 각 카드가 소유하고 있는 공개키
+     */
+    @Column(name = "public_key", columnDefinition = "TEXT", nullable = false)
+    private String publicKey;
+}

--- a/src/main/java/com/fisa/appcard/dto/request/RegisterKeyRequest.java
+++ b/src/main/java/com/fisa/appcard/dto/request/RegisterKeyRequest.java
@@ -1,0 +1,26 @@
+package com.fisa.appcard.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 카드 공개키 등록 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RegisterKeyRequest {
+
+    /**
+     * 카드 고유 ID (문자열)
+     */
+    private String cardId;
+
+    /**
+     * 카드의 Base64 인코딩 공개키
+     */
+    private String publicKey;
+}

--- a/src/main/java/com/fisa/appcard/dto/response/ChallengeResponse.java
+++ b/src/main/java/com/fisa/appcard/dto/response/ChallengeResponse.java
@@ -1,0 +1,18 @@
+package com.fisa.appcard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챌린지 반환 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeResponse {
+
+    private String challenge;
+}

--- a/src/main/java/com/fisa/appcard/repository/AppCardKeyRepository.java
+++ b/src/main/java/com/fisa/appcard/repository/AppCardKeyRepository.java
@@ -1,0 +1,8 @@
+package com.fisa.appcard.repository;
+
+import com.fisa.appcard.domain.AppCardKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppCardKeyRepository extends JpaRepository<AppCardKey, String> {}

--- a/src/main/java/com/fisa/appcard/service/AuthService.java
+++ b/src/main/java/com/fisa/appcard/service/AuthService.java
@@ -1,9 +1,11 @@
 package com.fisa.appcard.service;
 
+import com.fisa.appcard.domain.AppCardKey;
 import com.fisa.appcard.domain.AuthStatus;
 import com.fisa.appcard.domain.AuthenticationSession;
 import com.fisa.appcard.dto.request.InitiateAuthRequest;
 import com.fisa.appcard.dto.response.InitiateAuthResponse;
+import com.fisa.appcard.repository.AppCardKeyRepository;
 import com.fisa.appcard.repository.AuthSessionRepository;
 import com.fisa.appcard.utils.ChallengeUtil;
 import jakarta.transaction.Transactional;
@@ -19,6 +21,7 @@ import java.time.LocalDateTime;
 public class AuthService {
 
     private final AuthSessionRepository authSessionRepository;
+    private final AppCardKeyRepository keyRepository;
 
     private final ChallengeUtil generator;
 
@@ -54,11 +57,23 @@ public class AuthService {
 
     /**
      * txnId에 해당하는 인증세션의 챌린지 값을 반환합니다.
+     *
      * @param txnId
      * @return challenge
      */
     public String getChallenge(String txnId) {
         return authSessionRepository.findById(txnId).orElseThrow().getChallenge();
+    }
+
+    /**
+     * 카드의 공개키를 저장합니다.
+     *
+     * @param cardId    저장할 카드의 고유 ID
+     * @param publicKey 카드의 Base64 인코딩 공개키
+     */
+    public void registerPublicKey(String cardId, String publicKey) {
+        AppCardKey key = new AppCardKey(cardId, publicKey);
+        keyRepository.save(key);
     }
 
 }

--- a/src/main/java/com/fisa/appcard/service/AuthService.java
+++ b/src/main/java/com/fisa/appcard/service/AuthService.java
@@ -52,4 +52,13 @@ public class AuthService {
         return new InitiateAuthResponse(deepLink);
     }
 
+    /**
+     * txnId에 해당하는 인증세션의 챌린지 값을 반환합니다.
+     * @param txnId
+     * @return challenge
+     */
+    public String getChallenge(String txnId) {
+        return authSessionRepository.findById(txnId).orElseThrow().getChallenge();
+    }
+
 }


### PR DESCRIPTION
# 🚀 개요
`GET /authentications/{txnId}/challenge` 엔드포인트를 추가하여  
거래 ID(txnId)에 대한 챌린지 값을 조회할 수 있도록 하는 API를 구현했습니다.

## 🔍 변경사항
- AuthebticationController: Challenge 조회 핸들러 추가  
- AuthService: `getChallenge(txnId)` 로직 및 예외 처리  
- DTO: `ChallengeResponse` 클래스 도입
- ExceptionHandler: 세션 미존재 시 404 반환  

## ⏳ 작업 내용
- [x] Controller 라우팅 및 요청 경로 매핑
- [x] Service 로직 & 예외 처리
- [x] DTO 클래스 변환 및 Lombok 적용

검토 부탁드립니다 :)