### PR TITLE
Feat: 검증 API 구현

### DIFF
--- a/src/main/java/com/fisa/appcard/config/OpenFeignConfig.java
+++ b/src/main/java/com/fisa/appcard/config/OpenFeignConfig.java
@@ -1,0 +1,22 @@
+package com.fisa.appcard.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * OpenFeign 관련 설정을 활성화하는 구성 클래스입니다.
+ * <p>
+ * 주요 역할:
+ * - Spring Cloud OpenFeign을 사용 가능하게 만듭니다.
+ * - 지정한 패키지 내의 FeignClient 인터페이스들을 스캔하여 Bean으로 등록합니다.
+ *
+ * @EnableFeignClients 설명:
+ * - basePackages 속성을 통해 FeignClient 인터페이스들이 위치한 패키지를 지정합니다.
+ * - "com.fisa.appcard.feign" 패키지에 정의된 Feign 인터페이스들이 자동으로 스캔됩니다.
+ */
+@Configuration
+@EnableFeignClients(basePackages = "com.fisa.appcard.feign")
+public class OpenFeignConfig {
+
+}

--- a/src/main/java/com/fisa/appcard/config/feign/PgClientConfig.java
+++ b/src/main/java/com/fisa/appcard/config/feign/PgClientConfig.java
@@ -1,0 +1,19 @@
+package com.fisa.appcard.config.feign;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+public class PgClientConfig {
+
+    @Value("${app.pg.token}")
+    private String token;
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            requestTemplate.header("Content-Type", "application/json");
+            requestTemplate.header("Authorization", "Bearer " + token);
+        };
+    }
+}

--- a/src/main/java/com/fisa/appcard/controller/AuthenticationController.java
+++ b/src/main/java/com/fisa/appcard/controller/AuthenticationController.java
@@ -2,9 +2,12 @@ package com.fisa.appcard.controller;
 
 import com.fisa.appcard.dto.request.InitiateAuthRequest;
 import com.fisa.appcard.dto.request.RegisterKeyRequest;
+import com.fisa.appcard.dto.request.VerifyRequest;
 import com.fisa.appcard.dto.response.ChallengeResponse;
 import com.fisa.appcard.dto.response.InitiateAuthResponse;
+import com.fisa.appcard.dto.response.VerifyResponse;
 import com.fisa.appcard.service.AuthService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -41,5 +44,15 @@ public class AuthenticationController {
         return ResponseEntity.ok().build();
     }
 
+    /**
+     * 검증 요청 API
+     */
+    @PostMapping("/{txnId}/verify")
+    public VerifyResponse verify(
+            @PathVariable String txnId,
+            @Valid @RequestBody VerifyRequest req
+    ) {
+        return new VerifyResponse(authService.verify(txnId, req.getCardId(), req.getSignature(), req.getCardNumber(), req.getCardType()));
+    }
 
 }

--- a/src/main/java/com/fisa/appcard/controller/AuthenticationController.java
+++ b/src/main/java/com/fisa/appcard/controller/AuthenticationController.java
@@ -41,4 +41,5 @@ public class AuthenticationController {
         return ResponseEntity.ok().build();
     }
 
+
 }

--- a/src/main/java/com/fisa/appcard/domain/AuthenticationSession.java
+++ b/src/main/java/com/fisa/appcard/domain/AuthenticationSession.java
@@ -32,12 +32,6 @@ public class AuthenticationSession {
     private String merchantName;
 
     /**
-     * 주문 ID
-     */
-    @Column(name = "order_id", nullable = false)
-    private String orderId;
-
-    /**
      * 챌린지(= 비어있는 인증 문서)
      */
     @Column(nullable = false)

--- a/src/main/java/com/fisa/appcard/domain/AuthenticationSession.java
+++ b/src/main/java/com/fisa/appcard/domain/AuthenticationSession.java
@@ -50,4 +50,25 @@ public class AuthenticationSession {
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
 
+    /**
+     * 인증 진행 중 상태로 인증 상태를 변경하는 메서드
+     */
+    public void pending() {
+        this.status = AuthStatus.PENDING;
+    }
+
+    /**
+     * 인증 완료 상태로 인증 상태를 변경하는 메서드
+     */
+    public void authenticate() {
+        this.status = AuthStatus.AUTHENTICATED;
+    }
+
+    /**
+     * 인증 실패 상태로 인증 상태를 변경하는 메서드
+     */
+    public void fail() {
+        this.status = AuthStatus.FAILED;
+    }
+
 }

--- a/src/main/java/com/fisa/appcard/domain/PaymentStatus.java
+++ b/src/main/java/com/fisa/appcard/domain/PaymentStatus.java
@@ -1,0 +1,5 @@
+package com.fisa.appcard.domain;
+
+public enum PaymentStatus {
+    SUCCESS, FAILED
+}

--- a/src/main/java/com/fisa/appcard/dto/request/InitiateAuthRequest.java
+++ b/src/main/java/com/fisa/appcard/dto/request/InitiateAuthRequest.java
@@ -29,9 +29,4 @@ public class InitiateAuthRequest {
      */
     private String merchantName;
 
-    /**
-     * 주문 ID
-     */
-    private String orderId;
-
 }

--- a/src/main/java/com/fisa/appcard/dto/request/VerifyRequest.java
+++ b/src/main/java/com/fisa/appcard/dto/request/VerifyRequest.java
@@ -1,0 +1,42 @@
+package com.fisa.appcard.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+/**
+ * 검증 요청 API 요청 DTO
+ * <br />
+ * 이 DTO는 결제 흐름 중 <b>30번째 단계</b>에서 사용됩니다.
+ * 자세한 내용은 프로젝트 내 {@code docs/payment-flow.md} 문서를 참고해 주세요.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifyRequest {
+
+    /**
+     * 시그니처 = 서명된 챌린지
+     */
+    @NotBlank
+    private String signature;
+
+    /**
+     * 카드 타입(CREDIT, CHECK)
+     */
+    @NotBlank
+    private String cardType;
+
+    /**
+     * 선택된 카드 번호
+     */
+    @NotBlank
+    private String cardNumber;
+
+    /**
+     * 선택된 카드 ID
+     */
+    @NotBlank
+    private String cardId;
+
+}

--- a/src/main/java/com/fisa/appcard/dto/response/VerifyResponse.java
+++ b/src/main/java/com/fisa/appcard/dto/response/VerifyResponse.java
@@ -1,0 +1,22 @@
+package com.fisa.appcard.dto.response;
+
+import lombok.*;
+
+/**
+ * 검증 요청 API 응답 DTO
+ * <br />
+ * 이 DTO는 결제 흐름 중 <b>31번째 단계</b>에서 사용됩니다.
+ * 자세한 내용은 프로젝트 내 {@code docs/payment-flow.md} 문서를 참고해 주세요.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifyResponse {
+
+    /**
+     * Flutter앱 내 개인키 서명에 대한 검증 결과 (T/F)
+     */
+    private boolean verified;
+
+}

--- a/src/main/java/com/fisa/appcard/feign/PgClient.java
+++ b/src/main/java/com/fisa/appcard/feign/PgClient.java
@@ -1,5 +1,6 @@
 package com.fisa.appcard.feign;
 
+import com.fisa.appcard.config.feign.PgClientConfig;
 import com.fisa.appcard.feign.dto.request.PgAuthorizeRequest;
 import com.fisa.appcard.feign.dto.response.BaseResponse;
 import com.fisa.appcard.feign.dto.response.PgAuthorizeResponse;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestBody;
  * - POST /payments/{txnId}/authorize
  * → 해당 트랜잭션(txnId)에 대한 인증 성공 여부 및 카드 정보를 PG 서버에 전달하여 결제 승인을 요청합니다.
  */
-@FeignClient(name = "pgClient", url = "${app.pg.endpoint")
+@FeignClient(name = "pgClient", url = "${app.pg.endpoint", configuration = PgClientConfig.class)
 public interface PgClient {
 
     /**

--- a/src/main/java/com/fisa/appcard/feign/PgClient.java
+++ b/src/main/java/com/fisa/appcard/feign/PgClient.java
@@ -1,0 +1,41 @@
+package com.fisa.appcard.feign;
+
+import com.fisa.appcard.feign.dto.request.PgAuthorizeRequest;
+import com.fisa.appcard.feign.dto.response.BaseResponse;
+import com.fisa.appcard.feign.dto.response.PgAuthorizeResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * PG(결제 대행) 서버와의 HTTP 통신을 추상화한 Feign 클라이언트 인터페이스
+ * <p>
+ * 주요 역할:
+ * - 앱 카드 인증 완료 후 결제 승인을 요청하기 위해 PG 서버에 REST API를 호출합니다.
+ *
+ * @FeignClient 설명:
+ * - name: FeignClient의 이름을 정의합니다. (스프링 컨테이너에서의 식별자)
+ * - url: 실제 PG 서버의 기본 URL을 지정합니다. (application.yml에서 pg.base-url로 설정)
+ * <p>
+ * 호출 대상 API:
+ * - POST /payments/{txnId}/authorize
+ * → 해당 트랜잭션(txnId)에 대한 인증 성공 여부 및 카드 정보를 PG 서버에 전달하여 결제 승인을 요청합니다.
+ */
+@FeignClient(name = "pgClient", url = "${app.pg.endpoint")
+public interface PgClient {
+
+    /**
+     * PG 서버에 인증 결과를 전달하고 결제 승인 요청을 보냅니다.
+     *
+     * @param txnId   트랜잭션 ID (URL 경로 변수로 전달됨)
+     * @param request 결제 승인에 필요한 정보가 담긴 요청 본문 객체
+     * @return PG 서버로부터 받은 승인 응답 객체
+     */
+    @PostMapping("/payments/{txnId}/authorize")
+    ResponseEntity<BaseResponse<PgAuthorizeResponse>> authorize(
+            @PathVariable("txnId") String txnId,
+            @RequestBody PgAuthorizeRequest request
+    );
+}

--- a/src/main/java/com/fisa/appcard/feign/dto/request/PgAuthorizeRequest.java
+++ b/src/main/java/com/fisa/appcard/feign/dto/request/PgAuthorizeRequest.java
@@ -1,0 +1,44 @@
+package com.fisa.appcard.feign.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 인증 성공 요청 API DTO
+ * <br />
+ * 이 DTO는 결제 흐름 중 <b>32번째 단계</b>에서 사용됩니다.
+ * 자세한 내용은 프로젝트 내 {@code docs/payment-flow.md} 문서를 참고해 주세요.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PgAuthorizeRequest {
+
+    /**
+     * 결제 트랜잭션 ID
+     */
+    private String txnId;
+
+    /**
+     * 인증 여부
+     */
+    private boolean authenticated;
+
+    /**
+     * 인증 완료 시각
+     */
+    private String authenticatedAt;
+
+    /**
+     * 결제 카드 번호
+     */
+    private String cardNumber;
+
+    /**
+     * 카드 종류(예: CREDIT, DEBIT)
+     */
+    private String cardType;
+}

--- a/src/main/java/com/fisa/appcard/feign/dto/response/BaseResponse.java
+++ b/src/main/java/com/fisa/appcard/feign/dto/response/BaseResponse.java
@@ -1,0 +1,15 @@
+package com.fisa.appcard.feign.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BaseResponse<T> {
+    private boolean success;
+    private String code;
+    private String message;
+    private T data;
+}

--- a/src/main/java/com/fisa/appcard/feign/dto/response/PgAuthorizeResponse.java
+++ b/src/main/java/com/fisa/appcard/feign/dto/response/PgAuthorizeResponse.java
@@ -1,0 +1,31 @@
+package com.fisa.appcard.feign.dto.response;
+
+import com.fisa.appcard.domain.PaymentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 결제 성공 응답 API DTO
+ * <br />
+ * 이 DTO는 결제 흐름 중 <b>48번째 단계</b>에서 사용됩니다.
+ * 자세한 내용은 프로젝트 내 {@code docs/payment-flow.md} 문서를 참고해 주세요.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PgAuthorizeResponse {
+
+    /**
+     * 결제 트랜잭션 ID
+     */
+    private String txnId;
+
+    /**
+     * 결제 상태(SUCCESS, FAILED)
+     */
+    private PaymentStatus paymentStatus;
+
+
+
+}

--- a/src/main/java/com/fisa/appcard/service/AuthService.java
+++ b/src/main/java/com/fisa/appcard/service/AuthService.java
@@ -8,13 +8,21 @@ import com.fisa.appcard.dto.response.InitiateAuthResponse;
 import com.fisa.appcard.repository.AppCardKeyRepository;
 import com.fisa.appcard.repository.AuthSessionRepository;
 import com.fisa.appcard.utils.ChallengeUtil;
+import com.fisa.appcard.utils.SignatureUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
 import java.time.LocalDateTime;
+import java.util.Base64;
 
 @Service
 @RequiredArgsConstructor
@@ -73,6 +81,83 @@ public class AuthService {
     public void registerPublicKey(String cardId, String publicKey) {
         AppCardKey key = new AppCardKey(cardId, publicKey);
         keyRepository.save(key);
+    }
+
+    /**
+     * 클라이언트가 전송한 서명을 통해 해당 사용자가 정당한 카드 소유자인지를 검증하는 메서드
+     *
+     * @param txnId              트랜잭션 ID (서버가 인증 세션을 구분하는 고유 식별자)
+     * @param cardId             사용자가 선택한 카드의 고유 ID
+     * @param signatureBase64Url 클라이언트(Flutter)가 전송한 서명값, URL-safe Base64 형식의 64바이트 Ed25519 서명 (raw r||s)
+     * @return 검증 성공 여부 (true: 인증 성공, false: 인증 실패)
+     */
+    public boolean verify(String txnId, String cardId, String signatureBase64Url) {
+        // 1. 인증 세션 조회
+        AuthenticationSession session = authSessionRepository.findById(txnId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "세션이 없습니다."));
+
+        // 2. 카드에 저장된 공개키 조회
+        PublicKey publicKey = getPublicKey(cardId);
+
+        // 3. 서명값 디코딩 (URL-safe Base64 → raw 64바이트 시그니처)
+        byte[] rawSig = Base64.getUrlDecoder().decode(signatureBase64Url);
+
+        // 4. 클라이언트가 받은 challenge 값을 올바르게 서명했는지 검증
+        boolean ok = SignatureUtil.check(
+                session.getChallenge(), // 서버가 발행한 challenge (텍스트 문자열)
+                rawSig,                 // 클라이언트가 서명한 시그니처 (64바이트)
+                publicKey               // 등록된 공개키
+        );
+
+        // 5. 검증 결과에 따라 세션 상태를 업데이트
+        if (ok) {
+            session.authenticate(); // 인증 성공 → 상태를 AUTHENTICATED로 변경
+        } else {
+            session.fail(); // 인증 실패 → 상태를 FAILED로 변경
+        }
+
+        return ok; // 최종 검증 결과 반환
+    }
+
+    /**
+     * 카드에 저장된 공개키(Base64로 인코딩된 raw Ed25519 공개키)를 조회해서 Java의 PublicKey 객체로 변환하는 메서드
+     *
+     * @param cardId 공개키를 조회할 카드의 고유 ID
+     * @return DER 인코딩이 적용된 Ed25519 Java PublicKey 객체
+     */
+    private PublicKey getPublicKey(String cardId) {
+        // 1. cardId로부터 저장된 공개키(Base64 형식) 조회
+        String publicKeyB64 = keyRepository.findById(cardId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "공개키가 존재하지 않습니다."))
+                .getPublicKey();
+
+        // 2. Base64 문자열을 디코딩하여 raw 공개키 바이트 추출 (32바이트)
+        byte[] raw = Base64.getDecoder().decode(publicKeyB64);
+
+        try {
+            // 3. Java KeyFactory가 요구하는 DER 인코딩을 수동으로 추가 (ASN.1 구조의 Ed25519 X.509 prefix)
+            // 이 prefix는 "SubjectPublicKeyInfo" 형식으로 만들어 주기 위한 템플릿
+            byte[] prefix = new byte[]{
+                    (byte) 0x30, (byte) 0x2a,              // SEQUENCE (전체 길이 0x2a = 42 bytes)
+                    (byte) 0x30, (byte) 0x05,              // SEQUENCE (알고리즘 ID)
+                    (byte) 0x06, (byte) 0x03,              // OBJECT IDENTIFIER (Ed25519)
+                    (byte) 0x2b, (byte) 0x65, (byte) 0x70, //   OID: 1.3.101.112 (Ed25519)
+                    (byte) 0x03, (byte) 0x21,              // BIT STRING (33 bytes = 0x21)
+                    (byte) 0x00                            // unused bits in BIT STRING = 0
+            };
+
+            // 4. prefix + raw 공개키를 합쳐서 최종 DER 형식의 바이트 배열 생성
+            byte[] der = new byte[prefix.length + raw.length];
+            System.arraycopy(prefix, 0, der, 0, prefix.length);
+            System.arraycopy(raw, 0, der, prefix.length, raw.length);
+
+            // 5. DER 인코딩된 바이트 배열을 X509EncodedKeySpec으로 감싸고 PublicKey 객체 생성
+            X509EncodedKeySpec spec = new X509EncodedKeySpec(der);
+            return KeyFactory.getInstance("Ed25519").generatePublic(spec);
+
+        } catch (GeneralSecurityException e) { // DER 형식 오류, 키 생성 실패 등의 오류가 발생한 경우
+            throw new IllegalStateException("유효하지 않은 공개키 형식입니다.", e);
+        }
     }
 
 }

--- a/src/main/java/com/fisa/appcard/service/AuthService.java
+++ b/src/main/java/com/fisa/appcard/service/AuthService.java
@@ -35,7 +35,6 @@ public class AuthService {
                 .txnId(req.getTxnId())
                 .amount(req.getAmount())
                 .merchantName(req.getMerchantName())
-                .orderId(req.getOrderId())
                 .challenge(challenge)
                 .status(AuthStatus.PENDING)
                 .expiresAt(LocalDateTime.now().plusSeconds(60))

--- a/src/main/java/com/fisa/appcard/utils/SignatureUtil.java
+++ b/src/main/java/com/fisa/appcard/utils/SignatureUtil.java
@@ -1,0 +1,56 @@
+package com.fisa.appcard.utils;
+
+import lombok.NoArgsConstructor;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.Signature;
+
+/**
+ * 전자 서명 검증을 위한 유틸리티 클래스
+ * <br />
+ * 이 클래스는 Ed25519 알고리즘 기반의 전자 서명을 검증하는 데 사용되며,
+ * 서버가 발급한 'challenge 문자열'에 대해 클라이언트가 생성한 서명을 확인하는 데 사용됩니다.
+ */
+@NoArgsConstructor
+public final class SignatureUtil {
+
+    static {
+        // 자바 내장 보안 프로바이더는 Ed25519 지원이 제한적일 수 있으므로,
+        // 다양한 알고리즘을 지원하는 BouncyCastle을 등록하여 확장성을 확보합니다.
+        // 이는 JVM 수준에서 한 번만 등록되며, Signature.getInstance(...) 호출 시 사용됩니다.
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    /**
+     * 클라이언트가 보낸 Ed25519 서명 값이, 서버가 발행한 원본 challenge 문자열에 대해 유효한지를 검증하는 메서드
+     *
+     * @param challenge    서명 검증 대상인 원본 문자열 (서버가 발행한 챌린지 문자열)
+     * @param derSignature Flutter 클라이언트가 Ed25519 개인키로 서명한 바이트 배열 (raw 64바이트)
+     *                     URL-safe Base64로 인코딩되어 왔다가 서버에서 decode됨
+     * @param publicKey    클라이언트(카드)에 등록된 Ed25519 공개키
+     * @return true: 서명이 challenge에 대해 유효한 경우 (해당 클라이언트가 진짜 키 소유자임)
+     * false: 서명 위조이거나, 잘못된 공개키를 사용한 경우
+     */
+    public static boolean check(String challenge, byte[] derSignature, PublicKey publicKey) {
+        try {
+            // Ed25519 알고리즘에 대한 Signature 객체 생성
+            Signature verifier = Signature.getInstance("Ed25519");
+
+            // 서명 검증 준비: 공개키 설정
+            verifier.initVerify(publicKey);
+
+            // 검증 대상 데이터 (challenge) 지정
+            verifier.update(challenge.getBytes(StandardCharsets.UTF_8));
+
+            // 서명 검증 수행
+            return verifier.verify(derSignature);
+
+        } catch (GeneralSecurityException e) { // 서명 검증 중 에러가 발생한 경우 (지원되지 않는 알고리즘, 키 오류 등)
+            return false; // 검증 실패로 간주
+        }
+    }
+}


### PR DESCRIPTION
# 🚀 개요
`POST /authentications/{txnId}/verify` 검증 API를 구현했습니다.  
클라이언트가 제출한 시그니처와 카드 정보를 AuthService.verify로 검증한 뒤,  
성공 시 PG 승인 요청(Feign `PgClient.authorize`)까지 연동합니다. -> 미구현

## 🔍 변경사항
- AuthenticationController
  - `/{txnId}/verify` 엔드포인트 추가
- DTO
-   `PgAuthorizeRequest`, `PgAuthorizeResponse` 연동 필드 확정
- AuthService
  - `verify(txnId, cardId, signature)` 로직 구현 (RSA 서명 검증)


## ⏳ 작업 내용
- [x] Controller 라우팅 및 검증/승인 흐름 구현
- [x] AuthService 서명 검증 로직 추가

검토 부탁드립니다 :)